### PR TITLE
Properly clone Buffer objects.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,11 @@ function plugin(options) {
       if (files[newName]) return done(new Error('metalsmith-copy: copying ' + file + ' to ' + newName + ' would overwrite file'));
 
       debug('copying file: ' + newName);
-      files[newName] = cloneDeep(files[file]);
+      files[newName] = cloneDeep(files[file], function(value) {
+        if (value instanceof Buffer) {
+          return new Buffer(value);
+        }
+      });
       if (options.move) {
         delete files[file];
       }


### PR DESCRIPTION
Lodash's `cloneDeep` function does not properly clone Node.js Buffer
objects, so a "customizer" function is needed to handle this case.

(This should fix #6.)