### PR TITLE
Skipping unchanged files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,10 @@ function plugin(options) {
         }
       }
 
+      if (newName === file) {
+        return;
+      }
+
       if (files[newName]) return done(new Error('metalsmith-copy: copying ' + file + ' to ' + newName + ' would overwrite file'));
 
       debug('copying file: ' + newName);


### PR DESCRIPTION
The check for existing files throws if the destination filename is unchanged.