### PR TITLE
Fix imports that broke when running in strict mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 var debug = require('debug')('metalsmith-copy'),
     path = require('path'),
-    cloneDeep = require('lodash').cloneDeep;
+    cloneDeep = require('lodash').cloneDeep,
     minimatch = require('minimatch');
 
 module.exports = plugin;


### PR DESCRIPTION
The badly place semicolon triggered "undefined variable" errors.