### PR TITLE
allow force overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ metalsmith-copy requires a `pattern` option as well as at least one of the trans
 - `directory` is a directory relative to the build directory for the new file to be copied.
 - `transform` supercedes both `extension` and `directory` and is a function which takes one argument (the path to the file being copied) and returns a new path for the file to be copied to.
 - `move` is boolean value indication files should be moved instead of copied.
+- `force` is a boolean value that defaults to false, but you can pass in true to force overwriting of destination files
 
 ## Use Cases
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ module.exports = plugin;
 function plugin(options) {
   return function(files, metalsmith, done) {
     if (!options.directory && !options.extension && !options.transform) return done(new Error('metalsmith-copy: "directory" or "extension" option required'));
+    if (!options.force) options.force = false;
 
     var matcher = minimatch.Minimatch(options.pattern);
 
@@ -30,7 +31,7 @@ function plugin(options) {
         }
       }
 
-      if (files[newName]) return done(new Error('metalsmith-copy: copying ' + file + ' to ' + newName + ' would overwrite file'));
+      if (files[newName] && options.force === false) return done(new Error('metalsmith-copy: copying ' + file + ' to ' + newName + ' would overwrite file'));
 
       debug('copying file: ' + newName);
       files[newName] = cloneDeep(files[file], function(value) {

--- a/test/index.js
+++ b/test/index.js
@@ -90,7 +90,7 @@ describe('metalsmith-copy', function() {
   });
 
   describe('error handling', function() {
-    it('should not overwrite files that already exist', function(done) {
+    it('should not overwrite files that already exist by default', function(done) {
       copy_test({
           pattern: '*.md',
           extension: '.md'
@@ -99,6 +99,18 @@ describe('metalsmith-copy', function() {
           done(new Error('overwrote file'));
         });
     });
+
+    it('should overwrite files that already exist if option is passed', function(done) {
+      copy_test({
+          pattern: '*.md',
+          extension: '.md',
+          force: true
+        }, function(err, files) {
+          if (!err) return done();
+          else done(new Error('did not overwrite file'));
+        });
+    });
+
 
     it('should fail if no valid options are specified', function(done) {
       copy_test({


### PR DESCRIPTION
## overview

As per the requests in mattwidmann/metalsmith-copy#4 mattwidmann/metalsmith-copy#5, it would be really nice to be able to force overwrite files when necessary.

## tasks

- [x] add `force` option 
- [x] default to false
- [x] skip error if true
- [x] add tests
- [x] update readme

@mattwidmann if you would, could you please merge and publish as 0.3.0 to npm and tag me when done so I can update deps and kill my fork.
